### PR TITLE
feat: make token-storage testable

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
     "prefer-destructuring": "off",
     "perfectionist/sort-objects": "off",
     "perfectionist/sort-object-types": "off",
-    "perfectionist/sort-union-types": "off"
+    "perfectionist/sort-union-types": "off",
+    "perfectionist/sort-imports": "off"
   },
   "overrides": [
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,8 @@
     "perfectionist/sort-objects": "off",
     "perfectionist/sort-object-types": "off",
     "perfectionist/sort-union-types": "off",
-    "perfectionist/sort-imports": "off"
+    "perfectionist/sort-imports": "off",
+    "perfectionist/sort-named-imports": "off"
   },
   "overrides": [
     {

--- a/src/util/token-storage.ts
+++ b/src/util/token-storage.ts
@@ -2,9 +2,13 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-const getReforgeDir = () => path.join(os.homedir(), '.reforge')
-const getTokenFile = () => path.join(getReforgeDir(), 'tokens.json')
-const getConfigFile = () => path.join(getReforgeDir(), 'config')
+export interface TokenStorageOptions {
+  reforgeDir?: string
+}
+
+const getReforgeDir = (options?: TokenStorageOptions) => options?.reforgeDir || path.join(os.homedir(), '.reforge')
+const getTokenFile = (options?: TokenStorageOptions) => path.join(getReforgeDir(options), 'tokens.json')
+const getConfigFile = (options?: TokenStorageOptions) => path.join(getReforgeDir(options), 'config')
 
 export interface TokenData {
   accessToken: string
@@ -22,8 +26,8 @@ export interface AuthConfig {
   }
 }
 
-const ensureReforgeDir = async () => {
-  const reforgeDir = getReforgeDir()
+const ensureReforgeDir = async (options?: TokenStorageOptions) => {
+  const reforgeDir = getReforgeDir(options)
   try {
     await fs.promises.access(reforgeDir, fs.constants.F_OK)
   } catch {
@@ -31,22 +35,22 @@ const ensureReforgeDir = async () => {
   }
 }
 
-export const saveTokens = async (tokens: TokenData): Promise<void> => {
-  await ensureReforgeDir()
-  await fs.promises.writeFile(getTokenFile(), JSON.stringify(tokens, null, 2), 'utf8')
+export const saveTokens = async (tokens: TokenData, options?: TokenStorageOptions): Promise<void> => {
+  await ensureReforgeDir(options)
+  await fs.promises.writeFile(getTokenFile(options), JSON.stringify(tokens, null, 2), 'utf8')
 }
 
-export const loadTokens = async (): Promise<TokenData | null> => {
+export const loadTokens = async (options?: TokenStorageOptions): Promise<TokenData | null> => {
   try {
-    const data = await fs.promises.readFile(getTokenFile(), 'utf8')
+    const data = await fs.promises.readFile(getTokenFile(options), 'utf8')
     return JSON.parse(data) as TokenData
   } catch {
     return null
   }
 }
 
-export const saveAuthConfig = async (config: AuthConfig): Promise<void> => {
-  await ensureReforgeDir()
+export const saveAuthConfig = async (config: AuthConfig, options?: TokenStorageOptions): Promise<void> => {
+  await ensureReforgeDir(options)
 
   let configContent = ''
 
@@ -66,12 +70,12 @@ export const saveAuthConfig = async (config: AuthConfig): Promise<void> => {
     configContent += '\n\n'
   }
 
-  await fs.promises.writeFile(getConfigFile(), configContent, 'utf8')
+  await fs.promises.writeFile(getConfigFile(options), configContent, 'utf8')
 }
 
-export const loadAuthConfig = async (): Promise<AuthConfig | null> => {
+export const loadAuthConfig = async (options?: TokenStorageOptions): Promise<AuthConfig | null> => {
   try {
-    const data = await fs.promises.readFile(getConfigFile(), 'utf8')
+    const data = await fs.promises.readFile(getConfigFile(options), 'utf8')
 
     const config: AuthConfig = {
       profiles: {},
@@ -106,15 +110,15 @@ export const loadAuthConfig = async (): Promise<AuthConfig | null> => {
 
 export const getActiveProfile = (profileArg?: string): string => profileArg || process.env.REFORGE_PROFILE || 'default'
 
-export const clearAuth = async (): Promise<void> => {
+export const clearAuth = async (options?: TokenStorageOptions): Promise<void> => {
   try {
-    await fs.promises.unlink(getTokenFile())
+    await fs.promises.unlink(getTokenFile(options))
   } catch {
     // Ignore if file doesn't exist
   }
 
   try {
-    await fs.promises.unlink(getConfigFile())
+    await fs.promises.unlink(getConfigFile(options))
   } catch {
     // Ignore if file doesn't exist
   }

--- a/src/util/token-storage.ts
+++ b/src/util/token-storage.ts
@@ -2,9 +2,9 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-const REFORGE_DIR = path.join(os.homedir(), '.reforge')
-const TOKEN_FILE = path.join(REFORGE_DIR, 'tokens.json')
-const CONFIG_FILE = path.join(REFORGE_DIR, 'config')
+const getReforgeDir = () => path.join(os.homedir(), '.reforge')
+const getTokenFile = () => path.join(getReforgeDir(), 'tokens.json')
+const getConfigFile = () => path.join(getReforgeDir(), 'config')
 
 export interface TokenData {
   accessToken: string
@@ -23,21 +23,22 @@ export interface AuthConfig {
 }
 
 const ensureReforgeDir = async () => {
+  const reforgeDir = getReforgeDir()
   try {
-    await fs.promises.access(REFORGE_DIR, fs.constants.F_OK)
+    await fs.promises.access(reforgeDir, fs.constants.F_OK)
   } catch {
-    await fs.promises.mkdir(REFORGE_DIR, {recursive: true})
+    await fs.promises.mkdir(reforgeDir, {recursive: true})
   }
 }
 
 export const saveTokens = async (tokens: TokenData): Promise<void> => {
   await ensureReforgeDir()
-  await fs.promises.writeFile(TOKEN_FILE, JSON.stringify(tokens, null, 2), 'utf8')
+  await fs.promises.writeFile(getTokenFile(), JSON.stringify(tokens, null, 2), 'utf8')
 }
 
 export const loadTokens = async (): Promise<TokenData | null> => {
   try {
-    const data = await fs.promises.readFile(TOKEN_FILE, 'utf8')
+    const data = await fs.promises.readFile(getTokenFile(), 'utf8')
     return JSON.parse(data) as TokenData
   } catch {
     return null
@@ -65,12 +66,12 @@ export const saveAuthConfig = async (config: AuthConfig): Promise<void> => {
     configContent += '\n\n'
   }
 
-  await fs.promises.writeFile(CONFIG_FILE, configContent, 'utf8')
+  await fs.promises.writeFile(getConfigFile(), configContent, 'utf8')
 }
 
 export const loadAuthConfig = async (): Promise<AuthConfig | null> => {
   try {
-    const data = await fs.promises.readFile(CONFIG_FILE, 'utf8')
+    const data = await fs.promises.readFile(getConfigFile(), 'utf8')
 
     const config: AuthConfig = {
       profiles: {},
@@ -107,13 +108,13 @@ export const getActiveProfile = (profileArg?: string): string => profileArg || p
 
 export const clearAuth = async (): Promise<void> => {
   try {
-    await fs.promises.unlink(TOKEN_FILE)
+    await fs.promises.unlink(getTokenFile())
   } catch {
     // Ignore if file doesn't exist
   }
 
   try {
-    await fs.promises.unlink(CONFIG_FILE)
+    await fs.promises.unlink(getConfigFile())
   } catch {
     // Ignore if file doesn't exist
   }

--- a/test/util/token-storage.test.ts
+++ b/test/util/token-storage.test.ts
@@ -8,16 +8,16 @@ import {type AuthConfig, getActiveProfile, loadAuthConfig, saveAuthConfig} from 
 
 describe('token-storage', () => {
   const testDir = path.join(os.tmpdir(), '.reforge-test-' + Date.now())
-  const configFile = path.join(testDir, 'config')
+  const configFile = path.join(testDir, '.reforge', 'config')
   let originalHome: string | undefined
 
   beforeEach(() => {
-    // Create test directory
-    fs.mkdirSync(testDir, {recursive: true})
+    // Create test directory and .reforge subdirectory
+    fs.mkdirSync(path.join(testDir, '.reforge'), {recursive: true})
 
     // Mock homedir to point to our test directory
     originalHome = process.env.HOME
-    process.env.HOME = testDir.replace('/.reforge-test-' + testDir.split('-').pop()!, '')
+    process.env.HOME = testDir
   })
 
   afterEach(() => {
@@ -124,6 +124,11 @@ workspace = workspace-work # Work Org - Work Workspace
     })
 
     it('should return null for missing file', async () => {
+      // Ensure config file doesn't exist
+      if (fs.existsSync(configFile)) {
+        fs.unlinkSync(configFile)
+      }
+
       const config = await loadAuthConfig()
       expect(config).to.be.null
     })

--- a/test/util/token-storage.test.ts
+++ b/test/util/token-storage.test.ts
@@ -10,22 +10,53 @@ describe('token-storage', () => {
   const testDir = path.join(os.tmpdir(), '.reforge-test-' + Date.now())
   const configFile = path.join(testDir, '.reforge', 'config')
   let originalHome: string | undefined
+  let originalUserProfile: string | undefined
+  let originalHomeDrive: string | undefined
+  let originalHomePath: string | undefined
 
   beforeEach(() => {
     // Create test directory and .reforge subdirectory
     fs.mkdirSync(path.join(testDir, '.reforge'), {recursive: true})
 
-    // Mock homedir to point to our test directory
+    // Mock homedir to point to our test directory for all platforms
+    // Save original values
     originalHome = process.env.HOME
+    originalUserProfile = process.env.USERPROFILE
+    originalHomeDrive = process.env.HOMEDRIVE
+    originalHomePath = process.env.HOMEPATH
+
+    // Set environment variables for both Unix and Windows
     process.env.HOME = testDir
+    process.env.USERPROFILE = testDir
+    // For Windows, we need to ensure HOMEDRIVE and HOMEPATH are not interfering
+    delete process.env.HOMEDRIVE
+    delete process.env.HOMEPATH
   })
 
   afterEach(() => {
-    // Restore original HOME
+    // Restore original environment variables
     if (originalHome === undefined) {
       delete process.env.HOME
     } else {
       process.env.HOME = originalHome
+    }
+
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE
+    } else {
+      process.env.USERPROFILE = originalUserProfile
+    }
+
+    if (originalHomeDrive === undefined) {
+      delete process.env.HOMEDRIVE
+    } else {
+      process.env.HOMEDRIVE = originalHomeDrive
+    }
+
+    if (originalHomePath === undefined) {
+      delete process.env.HOMEPATH
+    } else {
+      process.env.HOMEPATH = originalHomePath
     }
 
     // Clean up test directory

--- a/test/util/token-storage.test.ts
+++ b/test/util/token-storage.test.ts
@@ -2,7 +2,7 @@ import {expect} from '@oclif/test'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
-import {afterEach, beforeEach, describe, it} from 'node:test'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 
 import {type AuthConfig, getActiveProfile, loadAuthConfig, saveAuthConfig} from '../../src/util/token-storage.js'
 


### PR DESCRIPTION
Previously, we were loading the token storage path directories as constants, and when the `HOME` env var was being overridden, the files weren't being created where expected because `os.homedir()` had already been evaluated. How, we resolve it dynamically for each test to ensure it's evaluated using the env var for the specific test in question.