### PR TITLE
Remove NPM_AUTH_TOKEN requirement from dev environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn install --immutable
       - run: yarn build
+      - name: Configure npm authentication
+        run: |
+          echo "npmAuthToken: '\${NPM_AUTH_TOKEN}'" >> .yarnrc.yml
       - name: Publish to npm
         run: |
           if [ "${{ needs.check-version.outputs.is-prerelease }}" == "true" ]; then

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,2 @@
 nodeLinker: node-modules
 npmRegistryServer: 'https://registry.npmjs.org'
-npmAuthToken: '${NPM_AUTH_TOKEN}'


### PR DESCRIPTION
## Summary
- Remove `npmAuthToken` from `.yarnrc.yml`
- Inject NPM_AUTH_TOKEN dynamically in the GitHub release workflow before publishing
- Developers no longer need to set `NPM_AUTH_TOKEN` locally

## Changes
- Updated `.yarnrc.yml` to remove `npmAuthToken` line
- Added "Configure npm authentication" step in release workflow to inject token before publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)