### PR TITLE
fix: include type field in encrypted set-default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install -g @reforge-com/cli
 $ reforge COMMAND
 running command...
 $ reforge (--version)
-@reforge-com/cli/0.0.11 darwin-arm64 node-v24.4.1
+@reforge-com/cli/0.0.12 darwin-arm64 node-v22.12.0
 $ reforge --help [COMMAND]
 USAGE
   $ reforge COMMAND
@@ -91,7 +91,7 @@ EXAMPLES
   $ reforge create my.new.string --type json --value="{\"key\": \"value\"}"
 ```
 
-_See code: [src/commands/create.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/create.ts)_
+_See code: [src/commands/create.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/create.ts)_
 
 ## `reforge download`
 
@@ -124,7 +124,7 @@ EXAMPLES
   $ reforge download --environment=test --sdk-key=YOUR_SDK_KEY
 ```
 
-_See code: [src/commands/download.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/download.ts)_
+_See code: [src/commands/download.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/download.ts)_
 
 ## `reforge generate`
 
@@ -194,7 +194,7 @@ EXAMPLES
   $ reforge generate --targets node-ts -o ./dist # combine with targets
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/generate.ts)_
 
 ## `reforge generate-new-hex-key`
 
@@ -217,7 +217,7 @@ EXAMPLES
   $ reforge generate-new-hex-key
 ```
 
-_See code: [src/commands/generate-new-hex-key.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/generate-new-hex-key.ts)_
+_See code: [src/commands/generate-new-hex-key.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/generate-new-hex-key.ts)_
 
 ## `reforge get [NAME]`
 
@@ -250,7 +250,7 @@ EXAMPLES
   $ reforge get my.config.name --environment=production
 ```
 
-_See code: [src/commands/get.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/get.ts)_
+_See code: [src/commands/get.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/get.ts)_
 
 ## `reforge info [NAME]`
 
@@ -281,7 +281,7 @@ EXAMPLES
   $ reforge info my.config.name
 ```
 
-_See code: [src/commands/info.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/info.ts)_
 
 ## `reforge interactive`
 
@@ -299,7 +299,7 @@ EXAMPLES
   $ reforge
 ```
 
-_See code: [src/commands/interactive.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/interactive.ts)_
+_See code: [src/commands/interactive.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/interactive.ts)_
 
 ## `reforge list`
 
@@ -336,7 +336,7 @@ EXAMPLES
   $ reforge list --feature-flags
 ```
 
-_See code: [src/commands/list.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/list.ts)_
+_See code: [src/commands/list.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/list.ts)_
 
 ## `reforge login`
 
@@ -364,7 +364,7 @@ EXAMPLES
   $ reforge login --profile myprofile
 ```
 
-_See code: [src/commands/login.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/login.ts)_
 
 ## `reforge logout`
 
@@ -387,7 +387,7 @@ EXAMPLES
   $ reforge logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/logout.ts)_
 
 ## `reforge mcp`
 
@@ -420,7 +420,7 @@ EXAMPLES
   $ reforge mcp --url http://local-launch.goatsofreforge.com:3003/api/v1/mcp
 ```
 
-_See code: [src/commands/mcp.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/mcp.ts)_
+_See code: [src/commands/mcp.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/mcp.ts)_
 
 ## `reforge override [NAME]`
 
@@ -459,7 +459,7 @@ EXAMPLES
   $ reforge override my.double.config --value=3.14159
 ```
 
-_See code: [src/commands/override.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/override.ts)_
+_See code: [src/commands/override.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/override.ts)_
 
 ## `reforge profile`
 
@@ -482,7 +482,7 @@ EXAMPLES
   $ reforge profile
 ```
 
-_See code: [src/commands/profile.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/profile.ts)_
+_See code: [src/commands/profile.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/profile.ts)_
 
 ## `reforge schema NAME`
 
@@ -516,7 +516,7 @@ EXAMPLES
   $ reforge schema my-schema --get
 ```
 
-_See code: [src/commands/schema.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/schema.ts)_
+_See code: [src/commands/schema.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/schema.ts)_
 
 ## `reforge serve DATA-FILE`
 
@@ -552,7 +552,7 @@ EXAMPLES
   $ reforge serve ./reforge.test.588.config.json --port=3099
 ```
 
-_See code: [src/commands/serve.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/serve.ts)_
+_See code: [src/commands/serve.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/serve.ts)_
 
 ## `reforge set-default [NAME]`
 
@@ -596,7 +596,7 @@ EXAMPLES
   $ reforge set-default my.config.name --env-var=MY_ENV_VAR_NAME --environment=production
 ```
 
-_See code: [src/commands/set-default.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/set-default.ts)_
+_See code: [src/commands/set-default.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/set-default.ts)_
 
 ## `reforge whoami`
 
@@ -619,7 +619,7 @@ EXAMPLES
   $ reforge whoami
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/whoami.ts)_
 
 ## `reforge workspace`
 
@@ -642,7 +642,7 @@ EXAMPLES
   $ reforge workspace
 ```
 
-_See code: [src/commands/workspace.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.11/src/commands/workspace.ts)_
+_See code: [src/commands/workspace.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/workspace.ts)_
 <!-- commandsstop -->
 
 ## Local Development

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.11.0",
   "name": "@reforge-com/cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "author": "Jeffrey Chupp @semanticart",
   "bugs": {
     "url": "https://github.com/ReforgeHQ/cli/issues"

--- a/src/commands/set-default.ts
+++ b/src/commands/set-default.ts
@@ -252,7 +252,10 @@ export default class SetDefault extends APICommand {
           return this.err(encryptedValueResult.message || 'Failed to encrypt value')
         }
 
-        configValue = encryptedValueResult.value
+        configValue = {
+          type: 'string',
+          ...encryptedValueResult.value,
+        }
         successMessage += ' (encrypted)'
       } else {
         // Parse the value based on type and build value object

--- a/src/util/encryption.ts
+++ b/src/util/encryption.ts
@@ -206,6 +206,6 @@ export async function makeConfidentialValue(
   return success({
     confidential: true,
     decryptWith: secret.keyName,
-    string: encryption.encrypt(value, secretKey),
+    value: encryption.encrypt(value, secretKey),
   })
 }

--- a/test/responses/set-default.ts
+++ b/test/responses/set-default.ts
@@ -254,6 +254,17 @@ const setDefaultHandler = http.post('https://api.*/internal/ops/v1/set-default',
     return HttpResponse.json({error: `Invalid default value for int: ${body.value.value}`}, {status: 400})
   }
 
+  // Validate encrypted values have correct structure
+  if (body.value?.confidential && body.value?.decryptWith) {
+    // Encrypted values must have type and value fields
+    if (!body.value.type) {
+      return HttpResponse.json({error: 'Encrypted values must have a type field'}, {status: 400})
+    }
+    if (body.value.value === undefined) {
+      return HttpResponse.json({error: 'Encrypted values must have a value field'}, {status: 400})
+    }
+  }
+
   // Success response
   return HttpResponse.json({
     success: true,


### PR DESCRIPTION
## Summary

Fixes a bug where `set-default --secret` was not sending the `type` field and was using the wrong field name for encrypted values, causing the value to not be properly sent to the server.

## Problem

When setting encrypted values using `reforge set-default --secret`, the API payload was malformed:
- Missing the required `type` field
- Using `string` as the field name instead of `value`

This caused encrypted values to fail when sent to the `/internal/ops/v1/set-default` endpoint.

## Solution

1. **encryption.ts:209** - Changed field name from `string` to `value`
2. **set-default.ts:255-258** - Added `type: 'string'` field to encrypted values
3. **Test validation** - Added mock handler validation to ensure encrypted values have correct structure
4. **Version bump** - 0.0.11 → 0.0.12

## Payload Comparison

### Before (Incorrect) ❌
```json
{
  "configKey": "test.secret",
  "currentVersionId": 1,
  "environmentId": 5,
  "value": {
    "string": "encrypted-data--iv--tag",
    "confidential": true,
    "decryptWith": "reforge.secrets.encryption.key"
  }
}
```

### After (Correct) ✅
```json
{
  "configKey": "test.secret",
  "currentVersionId": 1,
  "environmentId": 5,
  "value": {
    "type": "string",
    "value": "encrypted-data--iv--tag",
    "confidential": true,
    "decryptWith": "reforge.secrets.encryption.key"
  }
}
```

## Files Changed

- `src/util/encryption.ts` - Fixed encrypted value field name
- `src/commands/set-default.ts` - Added type field to encrypted values
- `test/responses/set-default.ts` - Added validation for encrypted value structure
- `package.json` - Version bump to 0.0.12

## Test Plan

The existing test at `test/commands/set-default.test.ts:100-105` validates encrypted value creation. With the added mock handler validation, this test would fail before the fix and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)