### PR TITLE
Fix: use correct encryption key for environment-specific secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.0.13 - 2025-12-08
+
+- fix: string/number comparison issue
+
 ## 0.0.11 - 2025-11-24
 
 - fix: typos in 'reforge generate --help'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install -g @reforge-com/cli
 $ reforge COMMAND
 running command...
 $ reforge (--version)
-@reforge-com/cli/0.0.12 darwin-arm64 node-v22.12.0
+@reforge-com/cli/0.0.13 darwin-arm64 node-v24.4.1
 $ reforge --help [COMMAND]
 USAGE
   $ reforge COMMAND
@@ -91,7 +91,7 @@ EXAMPLES
   $ reforge create my.new.string --type json --value="{\"key\": \"value\"}"
 ```
 
-_See code: [src/commands/create.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/create.ts)_
+_See code: [src/commands/create.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/create.ts)_
 
 ## `reforge download`
 
@@ -124,7 +124,7 @@ EXAMPLES
   $ reforge download --environment=test --sdk-key=YOUR_SDK_KEY
 ```
 
-_See code: [src/commands/download.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/download.ts)_
+_See code: [src/commands/download.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/download.ts)_
 
 ## `reforge generate`
 
@@ -194,7 +194,7 @@ EXAMPLES
   $ reforge generate --targets node-ts -o ./dist # combine with targets
 ```
 
-_See code: [src/commands/generate.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/generate.ts)_
+_See code: [src/commands/generate.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/generate.ts)_
 
 ## `reforge generate-new-hex-key`
 
@@ -217,7 +217,7 @@ EXAMPLES
   $ reforge generate-new-hex-key
 ```
 
-_See code: [src/commands/generate-new-hex-key.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/generate-new-hex-key.ts)_
+_See code: [src/commands/generate-new-hex-key.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/generate-new-hex-key.ts)_
 
 ## `reforge get [NAME]`
 
@@ -250,7 +250,7 @@ EXAMPLES
   $ reforge get my.config.name --environment=production
 ```
 
-_See code: [src/commands/get.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/get.ts)_
+_See code: [src/commands/get.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/get.ts)_
 
 ## `reforge info [NAME]`
 
@@ -281,7 +281,7 @@ EXAMPLES
   $ reforge info my.config.name
 ```
 
-_See code: [src/commands/info.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/info.ts)_
+_See code: [src/commands/info.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/info.ts)_
 
 ## `reforge interactive`
 
@@ -299,7 +299,7 @@ EXAMPLES
   $ reforge
 ```
 
-_See code: [src/commands/interactive.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/interactive.ts)_
+_See code: [src/commands/interactive.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/interactive.ts)_
 
 ## `reforge list`
 
@@ -336,7 +336,7 @@ EXAMPLES
   $ reforge list --feature-flags
 ```
 
-_See code: [src/commands/list.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/list.ts)_
+_See code: [src/commands/list.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/list.ts)_
 
 ## `reforge login`
 
@@ -364,7 +364,7 @@ EXAMPLES
   $ reforge login --profile myprofile
 ```
 
-_See code: [src/commands/login.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/login.ts)_
+_See code: [src/commands/login.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/login.ts)_
 
 ## `reforge logout`
 
@@ -387,7 +387,7 @@ EXAMPLES
   $ reforge logout
 ```
 
-_See code: [src/commands/logout.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/logout.ts)_
+_See code: [src/commands/logout.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/logout.ts)_
 
 ## `reforge mcp`
 
@@ -420,7 +420,7 @@ EXAMPLES
   $ reforge mcp --url http://local-launch.goatsofreforge.com:3003/api/v1/mcp
 ```
 
-_See code: [src/commands/mcp.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/mcp.ts)_
+_See code: [src/commands/mcp.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/mcp.ts)_
 
 ## `reforge override [NAME]`
 
@@ -459,7 +459,7 @@ EXAMPLES
   $ reforge override my.double.config --value=3.14159
 ```
 
-_See code: [src/commands/override.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/override.ts)_
+_See code: [src/commands/override.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/override.ts)_
 
 ## `reforge profile`
 
@@ -482,7 +482,7 @@ EXAMPLES
   $ reforge profile
 ```
 
-_See code: [src/commands/profile.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/profile.ts)_
+_See code: [src/commands/profile.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/profile.ts)_
 
 ## `reforge schema NAME`
 
@@ -516,7 +516,7 @@ EXAMPLES
   $ reforge schema my-schema --get
 ```
 
-_See code: [src/commands/schema.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/schema.ts)_
+_See code: [src/commands/schema.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/schema.ts)_
 
 ## `reforge serve DATA-FILE`
 
@@ -552,7 +552,7 @@ EXAMPLES
   $ reforge serve ./reforge.test.588.config.json --port=3099
 ```
 
-_See code: [src/commands/serve.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/serve.ts)_
+_See code: [src/commands/serve.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/serve.ts)_
 
 ## `reforge set-default [NAME]`
 
@@ -596,7 +596,7 @@ EXAMPLES
   $ reforge set-default my.config.name --env-var=MY_ENV_VAR_NAME --environment=production
 ```
 
-_See code: [src/commands/set-default.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/set-default.ts)_
+_See code: [src/commands/set-default.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/set-default.ts)_
 
 ## `reforge whoami`
 
@@ -619,7 +619,7 @@ EXAMPLES
   $ reforge whoami
 ```
 
-_See code: [src/commands/whoami.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/whoami.ts)_
+_See code: [src/commands/whoami.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/whoami.ts)_
 
 ## `reforge workspace`
 
@@ -642,7 +642,7 @@ EXAMPLES
   $ reforge workspace
 ```
 
-_See code: [src/commands/workspace.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.12/src/commands/workspace.ts)_
+_See code: [src/commands/workspace.ts](https://github.com/ReforgeHQ/cli/blob/v0.0.13/src/commands/workspace.ts)_
 <!-- commandsstop -->
 
 ## Local Development

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.11.0",
   "name": "@reforge-com/cli",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": "Jeffrey Chupp @semanticart",
   "bugs": {
     "url": "https://github.com/ReforgeHQ/cli/issues"

--- a/src/util/encryption.ts
+++ b/src/util/encryption.ts
@@ -133,9 +133,7 @@ export async function makeConfidentialValue(
   // Check environment-specific config first
   if (keyConfig.environments && environmentId) {
     /* eslint-disable @typescript-eslint/no-explicit-any */
-    const envConfig = (keyConfig.environments as any[]).find(
-      (env: any) => String(env.id) === String(environmentId),
-    )
+    const envConfig = (keyConfig.environments as any[]).find((env: any) => String(env.id) === String(environmentId))
     /* eslint-enable @typescript-eslint/no-explicit-any */
     const ruleValue = envConfig?.rules?.[0]?.value
 

--- a/src/util/encryption.ts
+++ b/src/util/encryption.ts
@@ -134,7 +134,7 @@ export async function makeConfidentialValue(
   if (keyConfig.environments && environmentId) {
     /* eslint-disable @typescript-eslint/no-explicit-any */
     const envConfig = (keyConfig.environments as any[]).find(
-      (env: any) => env.id === Number.parseInt(environmentId, 10),
+      (env: any) => String(env.id) === String(environmentId),
     )
     /* eslint-enable @typescript-eslint/no-explicit-any */
     const ruleValue = envConfig?.rules?.[0]?.value
@@ -174,7 +174,7 @@ export async function makeConfidentialValue(
   // If we have an env var, resolve it
   if (envVar && !secretKey) {
     secretKey = process.env[envVar]
-    command.verboseLog(`Using env var ${envVar} to encrypt secret`)
+    command.log(`Encrypting with key from env var: ${envVar}`)
 
     if (typeof secretKey !== 'string') {
       return failure(`Failed to create secret: env var ${envVar} is not present`, {


### PR DESCRIPTION
## Problem
When encrypting secrets with `set-default --secret` for a specific environment (e.g., production), the CLI was using the wrong encryption key. It would fall back to the default environment's key instead of using the environment-specific key.

## Root Cause
The API returns environment IDs as strings (e.g., `"1085"`), but the code was using strict equality (`===`) to compare with `Number.parseInt(environmentId, 10)`, which returns a number. This caused the comparison to always fail:
```javascript
"1085" === 1085  // false
```

## Fix
Changed the comparison to use string comparison:
```javascript
String(env.id) === String(environmentId)
```

Now when setting a secret in production, it correctly uses `PREFAB_SECRET_KEY_PROD` instead of falling back to `PREFAB_SECRET_KEY`.

## Changes
- Fixed environment ID comparison in `src/util/encryption.ts`
- Added user-visible log message showing which env var is used for encryption
- Removed verbose debug logging

## Testing
Verified that:
1. Setting a secret in production now uses the correct `PREFAB_SECRET_KEY_PROD` env var
2. The encrypted value can be successfully decrypted by the Node client
3. The user sees which env var was used for encryption