### PR TITLE
fix: allow setting default value for [Default] environment in set-default command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "packageManager": "yarn@4.11.0",
   "name": "@reforge-com/cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "author": "Jeffrey Chupp @semanticart",
   "bugs": {
     "url": "https://github.com/ReforgeHQ/cli/issues"

--- a/src/commands/set-default.ts
+++ b/src/commands/set-default.ts
@@ -141,6 +141,7 @@ export default class SetDefault extends APICommand {
 
     // Get the environment
     const environment = await getEnvironment({
+      allowDefaultEnvironment: true,
       command: this,
       flags,
       message: 'Which environment would you like to change the default for?',


### PR DESCRIPTION
## Summary
- Adds `allowDefaultEnvironment: true` to the `getEnvironment()` call in `set-default` command
- This shows `[Default]` as an option in the interactive environment picker, allowing users to set base-level defaults
- Bumps version to 0.0.15

## Problem
When using `reforge set-default` interactively, users could only select environment-specific values (Production, Staging, etc.) but not the base `[Default]` value. The workaround was to use `--environment=[default]` flag directly.

## Test plan
- [x] Existing tests pass (284 passing)
- [ ] Manual test: `reforge set-default` now shows `[Default]` in the environment picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)